### PR TITLE
Change the rexml write to be the default -1

### DIFF
--- a/lib/documatic/open_document_text/template.rb
+++ b/lib/documatic/open_document_text/template.rb
@@ -206,8 +206,7 @@ module Documatic::OpenDocumentText
       # Pretty print the XML source
       xml_doc = REXML::Document.new(self.jar.read(filename))
       xml_text = String.new
-#      xml_doc.write(xml_text, Documatic.debug ? 0 : -1)
-      xml_doc.write(xml_text, 0)
+      xml_doc.write(xml_text, -1)
       return xml_text
     end
     


### PR DESCRIPTION
Otherwise you get spaces between the dynamic fields and the regular
text.  Setting it to -1 seems to get rid of that behavior.
